### PR TITLE
[BE][#38] DB table의 column 명 수정 

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/Card.java
+++ b/backend/src/main/java/com/example/backend/domain/Card.java
@@ -5,15 +5,15 @@ public class Card {
     private String title;
     private String content;
     private String authorSystem;
-    private String status;
+    private String columnName;
     private Long orderIndex;
 
-    public Card(Long id, String title, String content, String authorSystem, String status, Long orderIndex) {
+    public Card(Long id, String title, String content, String authorSystem, String columnName, Long orderIndex) {
         this.id = id;
         this.title = title;
         this.content = content;
         this.authorSystem = authorSystem;
-        this.status = status;
+        this.columnName = columnName;
         this.orderIndex = orderIndex;
     }
 
@@ -27,7 +27,7 @@ public class Card {
         private String title;
         private String content;
         private String authorSystem;
-        private String status;
+        private String columnName;
         private Long orderIndex;
 
         public Builder id(Long id) {
@@ -50,8 +50,8 @@ public class Card {
             return this;
         }
 
-        public Builder status(String status) {
-            this.status = status;
+        public Builder columnName(String columnName) {
+            this.columnName = columnName;
             return this;
         }
 
@@ -61,7 +61,7 @@ public class Card {
         }
 
         public Card build() {
-            return new Card(id, title, content, authorSystem, status, orderIndex);
+            return new Card(id, title, content, authorSystem, columnName, orderIndex);
         }
     }
 }

--- a/backend/src/main/java/com/example/backend/domain/Column.java
+++ b/backend/src/main/java/com/example/backend/domain/Column.java
@@ -9,8 +9,8 @@ import java.util.Map;
 public class Column {
     private final Map<String, List<CardListResponseDto>> cardMap = new HashMap<>();
 
-    public void addByStatus(String status, CardListResponseDto dto) {
-        List<CardListResponseDto> cardList = cardMap.get(status);
+    public void addByColumnName(String columnName, CardListResponseDto dto) {
+        List<CardListResponseDto> cardList = cardMap.get(columnName);
         cardList.add(dto);
     }
 

--- a/backend/src/main/java/com/example/backend/web/dto/CardMoveRequestDto.java
+++ b/backend/src/main/java/com/example/backend/web/dto/CardMoveRequestDto.java
@@ -8,18 +8,18 @@ public class CardMoveRequestDto {
     @ApiModelProperty(example = "현재 카드의 행 위치")
     private Long currentIndex;
     @ApiModelProperty(example = "현재 카드의 column")
-    private String currentStatus;
+    private String currentColumnName;
     @ApiModelProperty(example = "카드가 이동할 행 위치")
     private Long newIndex;
     @ApiModelProperty(example = "카드가 이동할 column")
-    private String newStatus;
+    private String newColumnName;
 
-    public CardMoveRequestDto(Long id, Long currentIndex, String currentStatus, Long newIndex, String newStatus) {
+    public CardMoveRequestDto(Long id, Long currentIndex, String currentColumnName, Long newIndex, String newColumnName) {
         this.id = id;
         this.currentIndex = currentIndex;
-        this.currentStatus = currentStatus;
+        this.currentColumnName = currentColumnName;
         this.newIndex = newIndex;
-        this.newStatus = newStatus;
+        this.newColumnName = newColumnName;
     }
 
     public Long getId() {
@@ -30,15 +30,15 @@ public class CardMoveRequestDto {
         return currentIndex;
     }
 
-    public String getCurrentStatus() {
-        return currentStatus;
+    public String getCurrentColumnName() {
+        return currentColumnName;
     }
 
     public Long getNewIndex() {
         return newIndex;
     }
 
-    public String getNewStatus() {
-        return newStatus;
+    public String getNewColumnName() {
+        return newColumnName;
     }
 }

--- a/backend/src/main/java/com/example/backend/web/dto/CardSaveRequestDto.java
+++ b/backend/src/main/java/com/example/backend/web/dto/CardSaveRequestDto.java
@@ -11,13 +11,13 @@ public class CardSaveRequestDto {
     @ApiModelProperty(example = "작성된 시스템")
     private String authorSystem;
     @ApiModelProperty(example = "작성된 column명")
-    private String status;
+    private String columnName;
 
-    public CardSaveRequestDto(String title, String content, String authorSystem, String status) {
+    public CardSaveRequestDto(String title, String content, String authorSystem, String columnName) {
         this.title = title;
         this.content = content;
         this.authorSystem = authorSystem;
-        this.status = status;
+        this.columnName = columnName;
     }
 
     public String getTitle() {
@@ -32,8 +32,8 @@ public class CardSaveRequestDto {
         return authorSystem;
     }
 
-    public String getStatus() {
-        return status;
+    public String getColumnName() {
+        return columnName;
     }
 
     public Card toEntity() {
@@ -41,7 +41,7 @@ public class CardSaveRequestDto {
                 .title(title)
                 .content(content)
                 .authorSystem(authorSystem)
-                .status(status)
+                .columnName(columnName)
                 .build();
     }
 }

--- a/backend/src/main/resources/sql/schema.sql
+++ b/backend/src/main/resources/sql/schema.sql
@@ -4,7 +4,7 @@ CREATE TABLE CARD (
     title varchar(50) NOT NULL,
     content varchar(500),
     author_system varchar(20) NOT NULL,
-    status ENUM('to_do', 'in_progress', 'done'),
+    column_name ENUM('to_do', 'in_progress', 'done'),
     deleted tinyint(1) DEFAULT 0,
     order_index int NOT NULL
 );
@@ -12,30 +12,30 @@ CREATE TABLE ACTION_LOG
 (
     id int AUTO_INCREMENT PRIMARY KEY,
     title varchar(50) NOT NULL,
-    cur_status ENUM('to_do', 'in_progress', 'done'),
-    prev_status ENUM('to_do', 'in_progress', 'done') default NULL,
-    action ENUM('add', 'remove', 'update', 'move'),
+    cur_column_name ENUM('to_do', 'in_progress', 'done'),
+    prev_column_name ENUM('to_do', 'in_progress', 'done') default NULL,
+    action_type ENUM('add', 'remove', 'update', 'move'),
     created_date DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 
-INSERT INTO CARD (title, content, author_system, status, order_index) VALUES (
-'테스트 글 제목1', '테스트 내용', 'iOS', 'to_do', (SELECT count(*) FROM CARD WHERE status = 'to_do')
+INSERT INTO CARD (title, content, author_system, column_name, order_index) VALUES (
+'테스트 글 제목1', '테스트 내용', 'iOS', 'to_do', (SELECT count(*) FROM CARD WHERE column_name = 'to_do')
 );
-INSERT INTO CARD (title, content, author_system, status, order_index) VALUES (
-'테스트 글 제목2', '테스트 내용', 'iOS', 'in_progress', (SELECT count(*) FROM CARD WHERE status = 'in_progress')
+INSERT INTO CARD (title, content, author_system, column_name, order_index) VALUES (
+'테스트 글 제목2', '테스트 내용', 'iOS', 'in_progress', (SELECT count(*) FROM CARD WHERE column_name = 'in_progress')
 );
-INSERT INTO CARD (title, content, author_system, status, order_index) VALUES (
-'테스트 글 제목3', '테스트 내용', 'iOS', 'to_do', (SELECT count(*) FROM CARD WHERE status = 'to_do')
+INSERT INTO CARD (title, content, author_system, column_name, order_index) VALUES (
+'테스트 글 제목3', '테스트 내용', 'iOS', 'to_do', (SELECT count(*) FROM CARD WHERE column_name = 'to_do')
 );
-INSERT INTO CARD (title, content, author_system, status, order_index) VALUES (
-'테스트 글 제목4', '테스트 내용', 'iOS', 'to_do', (SELECT count(*) FROM CARD WHERE status = 'to_do')
+INSERT INTO CARD (title, content, author_system, column_name, order_index) VALUES (
+'테스트 글 제목4', '테스트 내용', 'iOS', 'to_do', (SELECT count(*) FROM CARD WHERE column_name = 'to_do')
 );
-INSERT INTO CARD (title, content, author_system, status, order_index) VALUES (
-'테스트 글 제목5', '테스트 내용', 'iOS', 'done', (SELECT count(*) FROM CARD WHERE status = 'done')
+INSERT INTO CARD (title, content, author_system, column_name, order_index) VALUES (
+'테스트 글 제목5', '테스트 내용', 'iOS', 'done', (SELECT count(*) FROM CARD WHERE column_name = 'done')
 );
-INSERT INTO ACTION_LOG (title, cur_status, action) VALUES (
+INSERT INTO ACTION_LOG (title, cur_column_name, action_type) VALUES (
 '테스트1', 'to_do', 'add'
 );
-INSERT INTO ACTION_LOG (title, cur_status, prev_status, action) VALUES (
+INSERT INTO ACTION_LOG (title, cur_column_name, prev_column_name, action_type) VALUES (
 '테스트2', 'in_progress', 'to_do', 'add'
 );


### PR DESCRIPTION
작업목록
- [x] 각 column명의 의미를 명확하게 알 수 있도록 column 명 수정

세부사항
리스트 1 : 각 column을 나타내던 status -> column_name으로 수정, 각 로그의 유형을 나타내던 action->action_type으로 수정