### PR TITLE
[BE] 카드 이동 요청 dto 수정

### DIFF
--- a/backend/src/main/java/com/example/backend/web/dto/CardMoveRequestDto.java
+++ b/backend/src/main/java/com/example/backend/web/dto/CardMoveRequestDto.java
@@ -5,33 +5,19 @@ import io.swagger.annotations.ApiModelProperty;
 public class CardMoveRequestDto {
     @ApiModelProperty(example = "움직일 카드의 id")
     private Long id;
-    @ApiModelProperty(example = "현재 카드의 행 위치")
-    private Long currentIndex;
-    @ApiModelProperty(example = "현재 카드의 column")
-    private String currentColumnName;
     @ApiModelProperty(example = "카드가 이동할 행 위치")
     private Long newIndex;
     @ApiModelProperty(example = "카드가 이동할 column")
     private String newColumnName;
 
-    public CardMoveRequestDto(Long id, Long currentIndex, String currentColumnName, Long newIndex, String newColumnName) {
+    public CardMoveRequestDto(Long id, Long newIndex, String newColumnName) {
         this.id = id;
-        this.currentIndex = currentIndex;
-        this.currentColumnName = currentColumnName;
         this.newIndex = newIndex;
         this.newColumnName = newColumnName;
     }
 
     public Long getId() {
         return id;
-    }
-
-    public Long getCurrentIndex() {
-        return currentIndex;
-    }
-
-    public String getCurrentColumnName() {
-        return currentColumnName;
     }
 
     public Long getNewIndex() {


### PR DESCRIPTION
`CardMoveRequestDto`에서 currentIndex, currentColumnName 삭제하였습니다.

- 카드 id 정보만 알고 있으면 모든 정보를 db에서 조회할 수 있기 때문에 제거하였습니다.